### PR TITLE
Qa engineer task job offer candidate level

### DIFF
--- a/qa_engineer_task/README.md
+++ b/qa_engineer_task/README.md
@@ -19,14 +19,12 @@ All questions and discussion at
 
 
 
-
 ### Task-1
 
 1. There is a sample project https://github.com/dataengi/crm-seed with documentation and ready to deploy using docker. Try
 run it using "Try in PWD" in cloud or locally according to instruction "Running in presentation mode".
 2. Read project general documentation https://github.com/dataengi/crm-seed/wiki
 3. Login on web interface with default credentials
-
 
 
 ### Task-2
@@ -55,6 +53,14 @@ Add five new contacts from this table
 
 
 
+### Task-3
+1. Discover backend API for UI requests (https://github.com/dataengi/crm-seed)
+2. Discover Swagger implementation https://github.com/dataengi/crm-seed/blob/master/conf/routes. Try use it
+3. Verify Customer contacts management (Customer contacts managements) according
+[API Security Checklist](https://github.com/awesome-it-ternopil/API-Security-Checklist). Make report in SOLUTION.md
+and commit it.
+
 
 ## Recommended literature
 1. [OWASP Testing Guide v4 Table of Contents](https://www.owasp.org/index.php/OWASP_Testing_Guide_v4_Table_of_Contents)
+2. [API Security Checklist](https://github.com/awesome-it-ternopil/API-Security-Checklist)

--- a/qa_engineer_task/README.md
+++ b/qa_engineer_task/README.md
@@ -64,3 +64,4 @@ and commit it.
 ## Recommended literature
 1. [OWASP Testing Guide v4 Table of Contents](https://www.owasp.org/index.php/OWASP_Testing_Guide_v4_Table_of_Contents)
 2. [API Security Checklist](https://github.com/awesome-it-ternopil/API-Security-Checklist)
+3. [Use cases vs user stories in Agile development](https://www.boost.co.nz/blog/2012/01/use-cases-or-user-stories)

--- a/qa_engineer_task/README.md
+++ b/qa_engineer_task/README.md
@@ -55,7 +55,7 @@ Add five new contacts from this table
 
 ### Task-3
 1. Discover backend API for UI requests (https://github.com/dataengi/crm-seed)
-2. Discover Swagger implementation https://github.com/dataengi/crm-seed/blob/master/conf/routes. Try use it
+2. Discover Swagger implementation https://github.com/dataengi/crm-seed/blob/master/conf/routes. Try to execute API requests or create bug reports if they are.   
 3. Verify Customer contacts management (Customer contacts managements) according
 [API Security Checklist](https://github.com/awesome-it-ternopil/API-Security-Checklist). Make report in SOLUTION.md
 and commit it.


### PR DESCRIPTION
I think it would be better to save the result of task 3.1 as a project on the own (candidate) repository, so we could check testing results depending on the application in which an API testing has been done.